### PR TITLE
Fixed non draco export

### DIFF
--- a/glTF-BinExporter/GlTFExporterCommand.cs
+++ b/glTF-BinExporter/GlTFExporterCommand.cs
@@ -35,23 +35,20 @@ namespace glTF_BinExporter.glTF
         {
             GetObject go = Selection.GetValidExportObjects("Select objects to export.");
 
-            var opts = new ExportOptions() { UseDracoCompression = true, DracoCompressionLevel = 10, DracoQuantizationBits = 16, UseBinary = true };
+            var opts = new ExportOptions() { UseDracoCompression = false, DracoCompressionLevel = 10, DracoQuantizationBits = 16, UseBinary = true };
 
-            // NOTE: The following options can be useful in dev/debug:
-            //bool useDracoCompression = true;
-            //Rhino.Input.RhinoGet.GetBool("Compression", true, "None", "Draco", ref useDracoCompression);
-            //bool useBinary = true;
-            //Rhino.Input.RhinoGet.GetBool("Mode", true, "Text", "Binary", ref useBinary);
-            //bool includeMaterials = true;
-            //Rhino.Input.RhinoGet.GetBool("Materials", true, "Exclude", "Include", ref opts.IncludeMaterial);
-            //int dracoCompressionLevel = 10;
-            Rhino.Input.RhinoGet.GetInteger("Draco Compression Level (max=10)", true, ref opts.DracoCompressionLevel, 1, 10);
-            //bool quantizaionBits = true;
-            Rhino.Input.RhinoGet.GetInteger("Quantization", true, ref opts.DracoQuantizationBits, 8, 32);
-            //Rhino.Input.RhinoGet.GetBool("Draco Quantization", true, "B", "Bits 16 Bits", ref quantizaionBits);
-            //opts.DracoQuantizationBits = quantizaionBits ? 24 : 12;
+            Rhino.Input.RhinoGet.GetBool("Binary or Text", true, "Text", "Binary", ref opts.UseBinary);
 
-            var dialog = new SaveFileDialog() { DefaultExt = ".glb", Title = "Select glTF Binary file to export to.", Filter = "glTF Binary (*.glb) | *.glb" };
+            Rhino.Input.RhinoGet.GetBool("Compression", true, "None", "Draco", ref opts.UseDracoCompression);
+
+            if (opts.UseDracoCompression)
+            {
+                Rhino.Input.RhinoGet.GetInteger("Draco Compression Level (max=10)", true, ref opts.DracoCompressionLevel, 1, 10);
+                Rhino.Input.RhinoGet.GetInteger("Quantization", true, ref opts.DracoQuantizationBits, 8, 32);
+            }
+
+            var dialog = GetSaveFileDialog(opts.UseBinary);
+
             var fileSelected = dialog.ShowSaveDialog();
 
             if (!fileSelected) {
@@ -89,8 +86,32 @@ namespace glTF_BinExporter.glTF
                 return Result.Success;
             } catch (Exception e) {
                 RhinoApp.WriteLine("ERROR: Failed exporting selected geometry to file.");
+                System.Diagnostics.Debug.WriteLine(e.Message);
                 return Result.Failure;
             }
         }
+
+        private SaveFileDialog GetSaveFileDialog(bool binaryExport)
+        {
+            if(binaryExport)
+            {
+                return new SaveFileDialog()
+                {
+                    DefaultExt = ".glb",
+                    Title = "Select glTF Binary file to export to.",
+                    Filter = "glTF Binary (*.glb) | *.glb"
+                };
+            }
+            else //Text glTF
+            {
+                return new SaveFileDialog()
+                {
+                    DefaultExt = ".gltf",
+                    Title = "Select glTF file to export to.",
+                    Filter = "glTF Text (*.gltf) | *.gltf"
+                };
+            }
+        }
+
     }
 }

--- a/glTF-BinExporter/glTF/GlBuffer.cs
+++ b/glTF-BinExporter/glTF/GlBuffer.cs
@@ -29,6 +29,7 @@ namespace glTF_BinExporter.glTF
         public bool IsGLBinaryMode;
 
         // dump to byte[] with ".flatten" + .ToArray();
+        [JsonIgnore]
         public List<IEnumerable<byte>> RawBytes;
 
         public bool ShouldSerializeRawBytes()

--- a/glTF-BinExporter/glTF/GlBuffer.cs
+++ b/glTF-BinExporter/glTF/GlBuffer.cs
@@ -76,6 +76,22 @@ namespace glTF_BinExporter.glTF
             PrimitiveCount += 1;
         }
 
+        public void Add(Vector3d point)
+        {
+            // Switch GL coords for Y<=>Z
+            float[] coords = new float[] { (float)point.X, (float)point.Z, -(float)point.Y };
+            Add(coords);
+            PrimitiveCount += 1;
+        }
+
+        public void Add(Point2f point)
+        {
+            // Switch GL coords for Y<=>Z
+            float[] coords = new float[] { (float)point.X, -(float)point.Y };
+            Add(coords);
+            PrimitiveCount += 1;
+        }
+
         public void Add(MeshFace face)
         {
             if (face.IsTriangle)

--- a/glTF-BinExporter/glTF/GlTFRootModel.cs
+++ b/glTF-BinExporter/glTF/GlTFRootModel.cs
@@ -664,8 +664,8 @@ namespace glTF_BinExporter.glTF
                 {
                     bufferView = texCoordsBufferViewIdx,
                     count = rhinoMesh.TextureCoordinates.Count,
-                    min = new float[] { 0.0f, 0.0f },
-                    max = new float[] { 1.0f, 1.0f },
+                    min = new float[] { (float)texCoordsMin.X, (float)texCoordsMin.Y },
+                    max = new float[] { (float)texCoordsMax.X, (float)texCoordsMax.Y }
                 };
                 int texCoordsAccessorIdx = accessors.AddAndReturnIndex(texCoordsAccessor);
 

--- a/glTF-BinExporter/glTF/GlTFRootModel.cs
+++ b/glTF-BinExporter/glTF/GlTFRootModel.cs
@@ -535,22 +535,21 @@ namespace glTF_BinExporter.glTF
             {
                 // Create buffers for data (position, normals, indices etc.)
                 var vtxBuffer = new Buffer(ExportOptions.UseBinary);
-
-                var min = new Point3d() { X = Double.PositiveInfinity, Y = Double.PositiveInfinity, Z = Double.PositiveInfinity };
-                var max = new Point3d() { X = Double.NegativeInfinity, Y = Double.NegativeInfinity, Z = Double.NegativeInfinity };
+                var vtxMin = new Point3d() { X = Double.PositiveInfinity, Y = Double.PositiveInfinity, Z = Double.PositiveInfinity };
+                var vtxMax = new Point3d() { X = Double.NegativeInfinity, Y = Double.NegativeInfinity, Z = Double.NegativeInfinity };
                 foreach (var p in rhinoMesh.Vertices)
                 {
                     vtxBuffer.Add(p);
 
-                    min.X = Math.Min(min.X, p.X);
+                    vtxMin.X = Math.Min(vtxMin.X, p.X);
                     // Switch Y<=>Z for GL coords
-                    min.Y = Math.Min(min.Y, p.Z);
-                    min.Z = Math.Min(min.Z, -p.Y);
+                    vtxMin.Y = Math.Min(vtxMin.Y, p.Z);
+                    vtxMin.Z = Math.Min(vtxMin.Z, -p.Y);
 
-                    max.X = Math.Max(max.X, p.X);
+                    vtxMax.X = Math.Max(vtxMax.X, p.X);
                     // Switch Y<=>Z for GL coords
-                    max.Y = Math.Max(max.Y, p.Z);
-                    max.Z = Math.Max(max.Z, -p.Y);
+                    vtxMax.Y = Math.Max(vtxMax.Y, p.Z);
+                    vtxMax.Z = Math.Max(vtxMax.Z, -p.Y);
                 }
                 buffers.Add(vtxBuffer);
                 int vtxBufferIdx = buffers.Count - 1;
@@ -564,11 +563,41 @@ namespace glTF_BinExporter.glTF
                 int idsBufferIdx = buffers.Count - 1;
 
                 Buffer normalsBuffer = new Buffer(ExportOptions.UseBinary);
-                normalsBuffer.Add(rhinoMesh.Normals.ToFloatArray());
+                var normalsMin = new Point3d() { X = Double.PositiveInfinity, Y = Double.PositiveInfinity, Z = Double.PositiveInfinity };
+                var normalsMax = new Point3d() { X = Double.NegativeInfinity, Y = Double.NegativeInfinity, Z = Double.NegativeInfinity };
+                //normalsBuffer.Add(rhinoMesh.Normals.ToFloatArray());
+                foreach (var n in rhinoMesh.Normals)
+                {
+                    normalsBuffer.Add(n);
+
+                    normalsMin.X = Math.Min(normalsMin.X, n.X);
+                    // Switch Y<=>Z for GL coords
+                    normalsMin.Y = Math.Min(normalsMin.Y, n.Z);
+                    normalsMin.Z = Math.Min(normalsMin.Z, -n.Y);
+
+                    normalsMax.X = Math.Max(normalsMax.X, n.X);
+                    // Switch Y<=>Z for GL coords
+                    normalsMax.Y = Math.Max(normalsMax.Y, n.Z);
+                    normalsMax.Z = Math.Max(normalsMax.Z, -n.Y);
+                }
                 int normalsIdx = buffers.AddAndReturnIndex(normalsBuffer);
 
                 Buffer texCoordsBuffer = new Buffer(ExportOptions.UseBinary);
-                texCoordsBuffer.Add(rhinoMesh.TextureCoordinates.ToFloatArray());
+                var texCoordsMin = new Point2d() { X = Double.PositiveInfinity, Y = Double.PositiveInfinity };
+                var texCoordsMax = new Point2d() { X = Double.NegativeInfinity, Y = Double.NegativeInfinity };
+                foreach (var tx in rhinoMesh.TextureCoordinates)
+                {
+                    texCoordsBuffer.Add(tx);
+
+                    texCoordsMin.X = Math.Min(texCoordsMin.X, tx.X);
+                    // Switch Y<=>Z for GL coords
+                    texCoordsMin.Y = Math.Min(texCoordsMin.Y, -tx.Y);
+
+                    texCoordsMax.X = Math.Max(texCoordsMax.X, tx.X);
+                    // Switch Y<=>Z for GL coords
+                    texCoordsMax.Y = Math.Max(texCoordsMax.Y, -tx.Y);
+                }
+
                 int texCoordsIdx = buffers.AddAndReturnIndex(texCoordsBuffer);
 
                 // Create bufferviews
@@ -605,8 +634,8 @@ namespace glTF_BinExporter.glTF
                 {
                     bufferView = vtxBufferViewIdx,
                     count = vtxBuffer.PrimitiveCount,
-                    min = new float[] { (float)min.X, (float)min.Y, (float)min.Z },
-                    max = new float[] { (float)max.X, (float)max.Y, (float)max.Z }
+                    min = new float[] { (float)vtxMin.X, (float)vtxMin.Y, (float)vtxMin.Z },
+                    max = new float[] { (float)vtxMax.X, (float)vtxMax.Y, (float)vtxMax.Z }
                 };
 
                 accessors.Add(vtxAccessor);
@@ -626,8 +655,8 @@ namespace glTF_BinExporter.glTF
                 {
                     bufferView = normalsBufferViewIdx,
                     count = rhinoMesh.Normals.Count,
-                    min = new float[] { -1.0f, -1.0f, -1.0f },
-                    max = new float[] { 1.0f, 1.0f, 1.0f },
+                    min = new float[] { (float)normalsMin.X, (float)normalsMin.Y, (float)normalsMin.Z },
+                    max = new float[] { (float)normalsMax.X, (float)normalsMax.Y, (float)normalsMax.Z }
                 };
                 int normalsAccessorIdx = accessors.AddAndReturnIndex(normalsAccessor);
 

--- a/glTF-BinExporter/glTF/GlTFUtils.cs
+++ b/glTF-BinExporter/glTF/GlTFUtils.cs
@@ -157,5 +157,12 @@ namespace glTF_BinExporter.glTF
 
             outStream.Flush();
         }
+
+        public static int AddAndReturnIndex<T>(this List<T> list, T item)
+        {
+            list.Add(item);
+            return list.Count - 1;
+        }
+
     }
 }


### PR DESCRIPTION
Resolves #2 

It might be worth taking a close look at this one to see if I did anything crazy.

I had the save file dialog created based on whether its the binary (.glb) or text (.gtlf) and added back the other Rhino.Gets for the export options.

I also think you forgot to add the json ignore attribute over the buffers raw bytes field.

In the SerializeToGLB I made it so the buffers are cleared before you add the packed buffer. Otherwise all the BufferViews look at whatever the first buffer was and not the packed buffer since it's at the end.