### PR TITLE
Converted from general utility to a file export plugin

### DIFF
--- a/glTF-BinExporter/Properties/launchSettings.json
+++ b/glTF-BinExporter/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "glTF-BinExporterWin": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe"
+    }
+  }
+}

--- a/glTF-BinExporter/glTF/GlTFRootModel.cs
+++ b/glTF-BinExporter/glTF/GlTFRootModel.cs
@@ -56,9 +56,9 @@ namespace glTF_BinExporter.glTF
         }
 
         [JsonIgnore]
-        public ExportOptions ExportOptions;
+        public glTFExportOptions ExportOptions;
 
-        public RootModel(ExportOptions exportOptions)
+        public RootModel(glTFExportOptions exportOptions)
         {
             this.ExportOptions = exportOptions;
             asset = new Asset();

--- a/glTF-BinExporter/glTF/GlTFUtils.cs
+++ b/glTF-BinExporter/glTF/GlTFUtils.cs
@@ -107,7 +107,7 @@ namespace glTF_BinExporter.glTF
             return rhinoObjectsRes;
         }
 
-        public static void ExportText(MemoryStream outStream, IEnumerable<RhinoObject> rhinoObjects, ExportOptions exportOptions)
+        public static void ExportText(MemoryStream outStream, IEnumerable<RhinoObject> rhinoObjects, glTFExportOptions exportOptions)
         {
             RootModel mdl = new RootModel(exportOptions);
 
@@ -137,7 +137,7 @@ namespace glTF_BinExporter.glTF
             outStream.Flush();
         }
 
-        public static void ExportBinary(MemoryStream outStream, IEnumerable<RhinoObject> rhinoObjects, ExportOptions exportOptions)
+        public static void ExportBinary(MemoryStream outStream, IEnumerable<RhinoObject> rhinoObjects, glTFExportOptions exportOptions)
         {
             RootModel mdl = new RootModel(exportOptions);
 
@@ -162,6 +162,13 @@ namespace glTF_BinExporter.glTF
         {
             list.Add(item);
             return list.Count - 1;
+        }
+
+        public static bool IsFileGltfBinary(string filename)
+        {
+            string extension = Path.GetExtension(filename);
+
+            return extension.ToLower() == ".glb";
         }
 
     }

--- a/glTF-BinExporter/glTFExportOptions.cs
+++ b/glTF-BinExporter/glTFExportOptions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace glTF_BinExporter
+{
+    public class glTFExportOptions
+    {
+        public bool UseDracoCompression = false;
+        public bool UseBinary = true;
+        public int DracoCompressionLevel = 10;
+        public int DracoQuantizationBits = 16;
+    }
+}

--- a/glTF-BinExporter/glTFExportOptionsDialog.cs
+++ b/glTF-BinExporter/glTFExportOptionsDialog.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Eto.Forms;
+
+namespace glTF_BinExporter
+{
+    class ExportOptionsDialog : Dialog<glTFExportOptions>
+    {
+        private CheckBox useDracoCompressionCheck = new CheckBox();
+
+        private Label dracoCompressionLabel = new Label();
+        private NumericStepper dracoCompressionLevelInput = new NumericStepper();
+
+        private Label dracoQuantizationBitsLabel = new Label();
+        private NumericStepper dracoQuantizationBitsInput = new NumericStepper();
+        
+        private Button cancelButton = new Button();
+        private Button okButton = new Button();
+
+        private glTFExportOptions options = null;
+
+        public ExportOptionsDialog(glTFExportOptions options)
+        {
+            this.options = options;
+
+            useDracoCompressionCheck.Text = "Use Draco Compression";
+
+            dracoCompressionLabel.Text = "Draco Compression Level";
+            dracoCompressionLevelInput.DecimalPlaces = 0;
+            dracoCompressionLevelInput.MinValue = 1;
+            dracoCompressionLevelInput.MaxValue = 10;
+
+            dracoQuantizationBitsLabel.Text = "Quantization";
+            dracoQuantizationBitsInput.DecimalPlaces = 0;
+            dracoQuantizationBitsInput.MinValue = 8;
+            dracoQuantizationBitsInput.MaxValue = 32;
+
+            cancelButton.Text = "Cancel";
+
+            okButton.Text = "Ok";
+
+            OptionsToDialog();
+
+            useDracoCompressionCheck.CheckedChanged += UseDracoCompressionCheck_CheckedChanged;
+            dracoCompressionLevelInput.ValueChanged += DracoCompressionLevelInput_ValueChanged;
+            dracoQuantizationBitsInput.ValueChanged += DracoQuantizationBitsInput_ValueChanged;
+
+            cancelButton.Click += CancelButton_Click;
+            okButton.Click += OkButton_Click;
+
+            this.Content = new TableLayout()
+            {
+                Padding = 5,
+                Spacing = new Eto.Drawing.Size(2, 2),
+                Rows =
+                {
+                    new TableRow(useDracoCompressionCheck, null),
+                    new TableRow(dracoCompressionLabel, dracoCompressionLevelInput),
+                    new TableRow(dracoQuantizationBitsLabel, dracoQuantizationBitsInput),
+                    new TableRow(cancelButton, okButton),
+                    null,
+                }
+            };
+        }
+
+        private void OptionsToDialog()
+        {
+            useDracoCompressionCheck.Checked = options.UseDracoCompression;
+
+            EnableDisableDracoControls(options.UseDracoCompression);
+
+            dracoCompressionLevelInput.Value = options.DracoCompressionLevel;
+            dracoQuantizationBitsInput.Value = options.DracoQuantizationBits;
+        }
+
+        private void EnableDisableDracoControls(bool enable)
+        {
+            dracoCompressionLevelInput.Enabled = enable;
+            dracoQuantizationBitsInput.Enabled = enable;
+        }
+
+        private void UseDracoCompressionCheck_CheckedChanged(object sender, EventArgs e)
+        {
+            bool useDraco = useDracoCompressionCheck.Checked.HasValue ? useDracoCompressionCheck.Checked.Value : false;
+
+            options.UseDracoCompression = useDraco;
+
+            EnableDisableDracoControls(useDraco);
+        }
+
+        private void DracoCompressionLevelInput_ValueChanged(object sender, EventArgs e)
+        {
+            int level = (int)dracoCompressionLevelInput.Value;
+
+            options.DracoCompressionLevel = level;
+        }
+
+        private void DracoQuantizationBitsInput_ValueChanged(object sender, EventArgs e)
+        {
+            int bits = (int)dracoQuantizationBitsInput.Value;
+
+            options.DracoQuantizationBits = bits;
+        }
+
+        private void CancelButton_Click(object sender, EventArgs e)
+        {
+            this.Close(null);
+        }
+
+        private void OkButton_Click(object sender, EventArgs e)
+        {
+            this.Close(options);
+        }
+
+    }
+}


### PR DESCRIPTION
Resolves #12 

This is another larger change. I added a dialog for the export options. We can add the Z to Y mapping option from #21 there. The plugin class was changed to an export and the supporting code added. I added the gltf and glb options to the save file dialog filter. Now the binary option is inferred from the name. 