### PR TITLE
Improved Material Conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ $ /Applications/Rhino\ 7.app/Contents/Resources/bin/yak build
 $ /Applications/Rhino\ 7.app/Contents/Resources/bin/yak push gltf-binexporter-XXXXXXX-any.yak
 ```
 
-## OS X Specific Instructions
-This repo uses git submodules. To build them on OS X, make sure they are checked out, and go to `glTF-CSharp-Loader`. Ensure this PR has been merged: https://github.com/KhronosGroup/glTF-CSharp-Loader/pull/33https://github.com/KhronosGroup/glTF-CSharp-Loader/pull/33, then build the project.
-
 # Sponsors
 [Stykka ApS](https://stykka.com)
 [McNeel](https://rhino3d.com)

--- a/glTF-BinExporter/GlTFExporterCommand.cs
+++ b/glTF-BinExporter/GlTFExporterCommand.cs
@@ -68,7 +68,7 @@ namespace glTF_BinExporter
                                 .Select(o => o.Object())
                                 .ToArray();
 
-            if(!DoExport(dialog.FileName, opts, rhinoObjects))
+            if(!DoExport(dialog.FileName, opts, rhinoObjects, doc.RenderSettings.LinearWorkflow))
             {
                 return Result.Failure;
             }
@@ -86,11 +86,11 @@ namespace glTF_BinExporter
             };
         }
 
-        public static bool DoExport(string fileName, glTFExportOptions opts, IEnumerable<Rhino.DocObjects.RhinoObject> rhinoObjects)
+        public static bool DoExport(string fileName, glTFExportOptions opts, IEnumerable<Rhino.DocObjects.RhinoObject> rhinoObjects, Rhino.Render.LinearWorkflow workflow)
         {
             try
             {
-                RhinoDocGltfConverter converter = new RhinoDocGltfConverter(opts, rhinoObjects);
+                RhinoDocGltfConverter converter = new RhinoDocGltfConverter(opts, rhinoObjects, workflow);
                 glTFLoader.Schema.Gltf gltf = converter.ConvertToGltf();
 
                 if(opts.UseBinary)

--- a/glTF-BinExporter/RhinoDocGltfConverter.cs
+++ b/glTF-BinExporter/RhinoDocGltfConverter.cs
@@ -17,20 +17,23 @@ namespace glTF_BinExporter
 {
     class RhinoDocGltfConverter
     {
-        public RhinoDocGltfConverter(glTFExportOptions options, IEnumerable<RhinoObject> objects)
+        public RhinoDocGltfConverter(glTFExportOptions options, IEnumerable<RhinoObject> objects, LinearWorkflow workflow)
         {
             this.options = options;
             this.objects = objects;
+            this.workflow = workflow;
         }
 
-        public RhinoDocGltfConverter(glTFExportOptions options, RhinoDoc doc)
+        public RhinoDocGltfConverter(glTFExportOptions options, RhinoDoc doc, LinearWorkflow workflow)
         {
             this.options = options;
             this.objects = doc.Objects;
+            this.workflow = null;
         }
 
         private IEnumerable<RhinoObject> objects = null;
         private glTFExportOptions options = null;
+        private LinearWorkflow workflow = null;
 
         private Dictionary<Guid, int> materialsMap = new Dictionary<Guid, int>();
 
@@ -230,13 +233,14 @@ namespace glTF_BinExporter
                 // Create mesh
                 primitives.Add(primitive);
             }
+
             var mesh = new glTFLoader.Schema.Mesh()
             {
                 Primitives = primitives.ToArray(),
             };
-            
+
             int meshIndex = dummy.Meshes.AddAndReturnIndex(mesh);
-            
+
             var node = new Node()
             {
                 Mesh = meshIndex,
@@ -624,7 +628,7 @@ namespace glTF_BinExporter
 
                 // Create mesh	
                 primitives.Add(primitive);	
-            }	
+            }
 
             var mesh = new glTFLoader.Schema.Mesh()
             {
@@ -806,7 +810,7 @@ namespace glTF_BinExporter
         {
             if(!materialsMap.TryGetValue(materialId, out int materialIndex))
             {
-                RhinoMaterialGltfConverter materialConverter = new RhinoMaterialGltfConverter(options, dummy, binaryBuffer, material);
+                RhinoMaterialGltfConverter materialConverter = new RhinoMaterialGltfConverter(options, dummy, binaryBuffer, material, workflow);
                 materialIndex = materialConverter.AddMaterial();
                 materialsMap.Add(materialId, materialIndex);
             }

--- a/glTF-BinExporter/RhinoMaterialGltfConverter.cs
+++ b/glTF-BinExporter/RhinoMaterialGltfConverter.cs
@@ -67,17 +67,17 @@ namespace glTF_BinExporter
                 material.PbrMetallicRoughness.RoughnessFactor = (float)rhinoMaterial.PhysicallyBased.Roughness;
             }
 
-            if (normalTexture != null)
+            if (normalTexture != null && normalTexture.Enabled)
             {
                 material.NormalTexture = AddTextureNormal(normalTexture);
             }
 
-            if (occlusionTexture != null)
+            if (occlusionTexture != null && occlusionTexture.Enabled)
             {
                 material.OcclusionTexture = AddTextureOcclusion(occlusionTexture.FileReference.FullPath);
             }
 
-            if (emissiveTexture != null)
+            if (emissiveTexture != null && emissiveTexture.Enabled)
             {
                 material.EmissiveTexture = AddTexture(emissiveTexture.FileReference.FullPath);
 
@@ -227,6 +227,8 @@ namespace glTF_BinExporter
                 {
                     double x = (double)i / ((double)(width - 1));
                     double y = (double)j / ((double)(height - 1));
+
+                    y = 1.0 - y;
 
                     Point3d uvw = new Point3d(x, y, 0.0);
 
@@ -407,14 +409,14 @@ namespace glTF_BinExporter
             {
                 for(int y = 0; y < height; y++)
                 {
-                    Point3d aLocation = new Point3d(Mod(x - 1, width) * widthScaler,  Mod(y - 1, height) * heightScaler, 0.0);
-                    Point3d bLocation = new Point3d(Mod(x, width) * widthScaler,      Mod(y - 1, height) * heightScaler, 0.0);
-                    Point3d cLocation = new Point3d(Mod(x + 1, width) * widthScaler,  Mod(y - 1, height) * heightScaler, 0.0);
-                    Point3d dLocation = new Point3d(Mod(x - 1, width) * widthScaler,  Mod(y, height) * heightScaler, 0.0);
-                    Point3d fLocation = new Point3d(Mod(x + 1, width) * widthScaler,  Mod(y, height) * heightScaler, 0.0);
-                    Point3d gLocation = new Point3d(Mod(x - 1, width) * widthScaler,  Mod(y + 1, height) * heightScaler, 0.0);
-                    Point3d hLocation = new Point3d(Mod(x, width) * widthScaler,      Mod(y + 1, height) * heightScaler, 0.0);
-                    Point3d iLocation = new Point3d(Mod(x + 1, width) * widthScaler,  Mod(y + 1, height) * heightScaler, 0.0);
+                    Point3d aLocation = new Point3d(Mod(x - 1, width) * widthScaler,  1.0 - Mod(y - 1, height) * heightScaler, 0.0);
+                    Point3d bLocation = new Point3d(Mod(x, width) * widthScaler,      1.0 - Mod(y - 1, height) * heightScaler, 0.0);
+                    Point3d cLocation = new Point3d(Mod(x + 1, width) * widthScaler,  1.0 - Mod(y - 1, height) * heightScaler, 0.0);
+                    Point3d dLocation = new Point3d(Mod(x - 1, width) * widthScaler,  1.0 - Mod(y, height) * heightScaler, 0.0);
+                    Point3d fLocation = new Point3d(Mod(x + 1, width) * widthScaler,  1.0 - Mod(y, height) * heightScaler, 0.0);
+                    Point3d gLocation = new Point3d(Mod(x - 1, width) * widthScaler,  1.0 - Mod(y + 1, height) * heightScaler, 0.0);
+                    Point3d hLocation = new Point3d(Mod(x, width) * widthScaler,      1.0 - Mod(y + 1, height) * heightScaler, 0.0);
+                    Point3d iLocation = new Point3d(Mod(x + 1, width) * widthScaler,  1.0 - Mod(y + 1, height) * heightScaler, 0.0);
 
                     float a = evaluator.GetColor(aLocation, Vector3d.Zero, Vector3d.Zero).L;
                     float b = evaluator.GetColor(bLocation, Vector3d.Zero, Vector3d.Zero).L;

--- a/glTF-BinExporter/glTF-BinExporterPlugin.cs
+++ b/glTF-BinExporter/glTF-BinExporterPlugin.cs
@@ -50,7 +50,7 @@ namespace glTF_BinExporter
 
             IEnumerable<Rhino.DocObjects.RhinoObject> objects = GetObjectsToExport(doc, options);
 
-            GlTFExporterCommand.DoExport(filename, gltfOptions, objects);
+            GlTFExporterCommand.DoExport(filename, gltfOptions, objects, doc.RenderSettings.LinearWorkflow);
 
             return WriteFileResult.Success;
         }


### PR DESCRIPTION
Hoping to resolve #34 and resolve #3 

I pass down Rhinos linear workflow to the material converter. This handles gamma correction on the textures for #3.

I filter out objects with no meshes in the sanitize objects method. There's a quirk with the new glTFLoader that doesn't like empty arrays. When the mesh is created the primitive list is empty and throws an exception. It's not logged as a bug but it makes the export fail. 

I try to fix most of what I wrote in #34. The gist of it is using the base color and metallic roughness if there's no textures. I also combine the PBR alpha map into the alpha channel of the base color texture. I'm using the texture evaluators just incase the textures aren't all the same size. I also prefer getting out the Color4f from them. Then I can use the Color4f.L (Luminosity) for the metallic/rougness/alpha textures intensity.