### PR TITLE
User model bugs

### DIFF
--- a/glTF-BinExporter/GlTFExporterCommand.cs
+++ b/glTF-BinExporter/GlTFExporterCommand.cs
@@ -100,7 +100,7 @@ namespace glTF_BinExporter
                 if(opts.UseBinary)
                 {
                     byte[] bytes = converter.GetBinaryBuffer();
-                    glTFLoader.Interface.SaveBinaryModel(gltf, bytes, fileName);
+                    glTFLoader.Interface.SaveBinaryModel(gltf, bytes.Length == 0 ? null : bytes, fileName);
                 }
                 else
                 {

--- a/glTF-BinExporter/GlTFUtils.cs
+++ b/glTF-BinExporter/GlTFUtils.cs
@@ -158,18 +158,16 @@ namespace glTF_BinExporter
             {
                 RhinoObject rhinoObject = instanceObject.InstanceDefinition.Object(i);
 
-                pieces.Add(rhinoObject);
-
                 if (rhinoObject is InstanceObject nestedObject)
                 {
                     Transform nestedTransform = instanceTransform * nestedObject.InstanceXform;
-
-                    transforms.Add(nestedTransform);
 
                     ExplodeRecursive(nestedObject, nestedTransform, pieces, transforms);
                 }
                 else
                 {
+                    pieces.Add(rhinoObject);
+
                     transforms.Add(instanceTransform);
                 }
             }

--- a/glTF-BinExporter/GlTFUtils.cs
+++ b/glTF-BinExporter/GlTFUtils.cs
@@ -45,7 +45,7 @@ namespace glTF_BinExporter
                 if(MeshIsValidForExport(mesh))
                 {
                     mesh.EnsurePrivateCopy();
-                    validMeshes.Append(mesh);
+                    validMeshes.Add(mesh);
                 }
             }
 

--- a/glTF-BinExporter/RhinoDocGltfConverter.cs
+++ b/glTF-BinExporter/RhinoDocGltfConverter.cs
@@ -109,7 +109,7 @@ namespace glTF_BinExporter
                 }
             }
 
-            if(options.UseBinary)
+            if(options.UseBinary && binaryBuffer.Count > 0)
             {
                 //have to add the empty buffer for the binary file header
                 dummy.Buffers.Add(new glTFLoader.Schema.Buffer()

--- a/glTF-BinExporter/RhinoMaterialGltfConverter.cs
+++ b/glTF-BinExporter/RhinoMaterialGltfConverter.cs
@@ -118,7 +118,7 @@ namespace glTF_BinExporter
             RenderTexture baseColorTexture = rhinoMaterial.RenderMaterial.GetTextureFromUsage(RenderMaterial.StandardChildSlots.PbrBaseColor);
             RenderTexture alphaTexture = rhinoMaterial.RenderMaterial.GetTextureFromUsage(RenderMaterial.StandardChildSlots.PbrAlpha);
 
-            bool baseColorLinear = IsLinear(baseColorTexture);
+            bool baseColorLinear = baseColorTexture == null ? false : IsLinear(baseColorTexture);
 
             bool hasBaseColorTexture = baseColorDoc == null ? false : baseColorDoc.Enabled;
             bool hasAlphaTexture = alphaTextureDoc == null ? false : alphaTextureDoc.Enabled;

--- a/glTF-BinExporter/glTF-BinExporterWin.csproj
+++ b/glTF-BinExporter/glTF-BinExporterWin.csproj
@@ -25,5 +25,7 @@
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="Copy &quot;$(TargetPath)&quot; &quot;$(TargetDir)$(ProjectName).rhp&quot;&#xD;&#xA;Erase &quot;$(TargetPath)&quot;&#xD;&#xA;powershell.exe -nologo -noprofile -command &quot;&amp; { if (Test-Path $(TargetDir)\glTF-BinExporter.rhi) { Remove-Item $(TargetDir)\glTF-BinExporter.rhi }; }&quot;&#xD;&#xA;powershell.exe -nologo -noprofile -command &quot;&amp; { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::CreateFromDirectory('.', '$(TargetDir)\..\glTF-BinExporter.rhi'); }&quot;&#xD;&#xA;" />
   </Target>
-  
+  <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes a few bugs I encountered with some user models I got from the forum

1. Added a null check before checking if a texture is linear
2. Filter out empty meshes. These can slip in occasionally, usually with trimmed objects
3. Fixed exceptions when writing a glb file when the binary buffer is empty. Shouldn't usually happen but it's a good sanity check.
4. I also stopped generating a AssemblyInfo.cs for the Windows project. That file has redefinitions for things like version numbers and was making the build a pain. There's currently a shared one we should be relying on.