### PR TITLE
Rhino PBR MaterialName fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ $ /Applications/Rhino\ 7.app/Contents/Resources/bin/yak push gltf-binexporter-XX
 
 [Peter Krattenmacher](https://github.com/pkratten)
 
+[Ali Tehami](https://github.com/alitehami)
+
 # License
 MIT but please make PRs if you make improvements.
 

--- a/glTF-BinExporter/RhinoMaterialGltfConverter.cs
+++ b/glTF-BinExporter/RhinoMaterialGltfConverter.cs
@@ -47,7 +47,7 @@ namespace glTF_BinExporter
             // Prep
             glTFLoader.Schema.Material material = new glTFLoader.Schema.Material()
             {
-                Name = rhinoMaterial.Name,
+                Name = renderMaterial.Name,
                 PbrMetallicRoughness = new glTFLoader.Schema.MaterialPbrMetallicRoughness(),
             };
 


### PR DESCRIPTION
Hello all,

Many thanks for this awesome project, much appreciate all your incredible efforts and work.

I've been having issues exporting the material names properly from rhino 7 and figured the plugin currently only work correctly with Rhino's most recent "Custom" Material type and a few others only, but mainly fails with PBRs. (it would not even work with older 'Custom' materials from older versions of rhino until they're reset and recreated in Rhino7).

Test with Grasshopper C# for both Render vs Simulated(which is how the current plugin is working) Materials Names:
![image](https://user-images.githubusercontent.com/38655738/134087606-71dfdb5d-330c-4b23-933f-56e3c56d9def.png)

glb models exported with both, the current plugin release (1.8) vs my PR version that relies on the RenderMaterial :

SimulatedMaterials:
![image](https://user-images.githubusercontent.com/38655738/134093584-399b9713-6ce4-488f-8a7a-0cc1308eb1ed.png)

RenderMaterials:
![image](https://user-images.githubusercontent.com/38655738/134093622-a75537cd-29c4-45c8-9c2b-4cf8c23c68b7.png)

Attached are the rhino & glb models for your reference:
[gltf-bin sample model for material names fixes.zip](https://github.com/Stykka/glTF-Bin/files/7199294/gltf-bin.sample.model.for.material.names.fixes.zip)

Thanks!
Ali Tehami
